### PR TITLE
ci: add ruby 3.3 to test matrix and remove 2.7, 3.0

### DIFF
--- a/.github/workflows/ruby-tests.yml
+++ b/.github/workflows/ruby-tests.yml
@@ -21,10 +21,9 @@ jobs:
           - faraday-1
           - faraday-2
         ruby-version:
+          - "3.3"
           - "3.2"
           - "3.1"
-          - "3.0"
-          - "2.7"
           - jruby
           - truffleruby
 
@@ -36,11 +35,11 @@ jobs:
         ruby-version: ${{ matrix.ruby-version }}
     - name: Set environment
       run: echo "COVERAGE=true" >> "$GITHUB_ENV"
-      if: matrix.ruby-version == '3.2' && matrix.gemfile == 'faraday-2'
+      if: matrix.ruby-version == '3.3' && matrix.gemfile == 'faraday-2'
     - name: Install dependencies
       run: bundle install
     - name: Run tests
       run: bundle exec rake test
     - name: Upload Coverage
       uses: paambaati/codeclimate-action@v3.2.0
-      if: matrix.ruby-version == '3.2' && matrix.gemfile == 'faraday-2'
+      if: matrix.ruby-version == '3.3' && matrix.gemfile == 'faraday-2'


### PR DESCRIPTION
2.7 and 3.0 are EOL, so no longer officially supported.